### PR TITLE
Maintain <code> block attributes (useCodeBlocks)

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -151,8 +151,8 @@ var self = this;
       // JS regexpes have some multiline issues, so we temporarily remove them
       return text
         .replace(/\n/g,'\uffff')
-        .replace(/<code>(.*?)<\/code>/gm, function(original, source){
-          return '<code>'+hljs.highlightText(source.replace(/\uffff/g,"\n"), tabReplace)+'</code>';
+        .replace(/<code([^>]*)>(.*?)<\/code>/gm, function(original, attrs, source){
+          return '<code'+attrs+'>'+hljs.highlightText(source.replace(/\uffff/g,"\n"), tabReplace)+'</code>';
         })
         .replace(/&amp;(\w+;)/g,'&$1').replace(/\uffff/g,"\n");
     } else {


### PR DESCRIPTION
Maintain code block attributes when using the useCodeBlocks option, as this allows explicit language definition using class="language-*" classes.
