### PR TITLE
Point directly to the highlight.js package on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DEPRECATION NOTICE
 ==================
 
-This project is deprecated in favor of [isagalaev/highlight.js](https://github.com/isagalaev/highlight.js). I never created the parser myself, the module was created in the early days of node as a wrapper for an existing browser based parser [highlight.js](http://softwaremaniacs.org/soft/highlight/en/) so if you are using this module and have problems with the parsing logic, I can't help you much as I'm not familiar with the inner details.
+This project is deprecated in favor of [highlight.js](https://www.npmjs.com/package/highlight.js). I never created the parser myself, the module was created in the early days of node as a wrapper for an existing browser based parser [highlight.js](http://softwaremaniacs.org/soft/highlight/en/) so if you are using this module and have problems with the parsing logic, I can't help you much as I'm not familiar with the inner details.
 
 Pull requests are still welcomed - if you find a bug and fix it, then I'll pull the change in but I won't be fixing the bugs myself. Sorry for that.
 


### PR DESCRIPTION
So folk who see this on npm can just click there, rather than going to github then back to npm.